### PR TITLE
Remove thoughtbot specific legal copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,15 +127,6 @@ See the [CONTRIBUTING] document. Thank you, [contributors]!
 [CONTRIBUTING]: CONTRIBUTING.md
 [contributors]: https://github.com/thoughtbot/Liftoff/graphs/contributors
 
-Need Help?
-----------
-
-We offer 1-on-1 coaching. We can help you with functional programming in Swift,
-get started writing unit tests, and convert from Objective-C to Swift.
-[Get in touch].
-
-[Get in touch]: http://coaching.thoughtbot.com/ios/?utm_source=github
-
 License
 -------
 
@@ -149,12 +140,5 @@ About
 
 ![thoughtbot](https://thoughtbot.com/logo.png)
 
-Liftoff is maintained and funded by thoughtbot, inc. The names and logos for
-thoughtbot are trademarks of thoughtbot, inc.
-
-We love open source software! See [our other projects][community] or look at
-our product [case studies] and [hire us][hire] to help build your iOS app.
-
-[community]: https://thoughtbot.com/community?utm_source=github
-[case studies]: https://thoughtbot.com/ios?utm_source=github
-[hire]: https://thoughtbot.com/hire-us?utm_source=github
+Liftoff was originally maintained and funded by thoughtbot, inc. The names and
+logos for thoughtbot are trademarks of thoughtbot, inc.


### PR DESCRIPTION
We're releasing this to the community, so this language isn't really
applicable anymore.

Also, we haven't offered coaching for literally _years_ why was this
still in there?